### PR TITLE
NGSTACK-771: fix translating ContentType

### DIFF
--- a/bundle/Resources/views/themes/ngadmin/content_type/tab/translations.html.twig
+++ b/bundle/Resources/views/themes/ngadmin/content_type/tab/translations.html.twig
@@ -1,0 +1,9 @@
+{% embed '@admin/content/tab/translations/tab.html.twig' with {
+    can_translate : can_translate,
+    form_translation_remove_action: path('ibexa.content_type.remove_translation')
+} %}
+    {% block modal_add_translation %}
+        {% include '@ibexadesign/content_type/modal/add_translation.html.twig' with {'form': form_translation_add} only %}
+    {% endblock %}
+{% endembed %}
+


### PR DESCRIPTION
The problem is that template for ContentType translation tab (`vendor/ibexa/admin-ui/src/bundle/Resources/views/themes/admin/content_type/tab/translations.html.twig`) uses embedding of `@ibexadesign/content/tab/translations/tab.html.twig` with block override. Since we've overridden that template, and are using inclusion of the original template there, block override does not work and the original add translation form is rendered.

This fixes the issue by overriding the template for ContentType translation tab to embed the original translation template `@admin/content/tab/translations/tab.html.twig`. I didn't find a better way to fix this issue.