### PR TITLE
Bugfix: set limit on countContentByContentType filter

### DIFF
--- a/bundle/Templating/Twig/BetterIbexaAdminUIRuntime.php
+++ b/bundle/Templating/Twig/BetterIbexaAdminUIRuntime.php
@@ -22,7 +22,7 @@ final class BetterIbexaAdminUIRuntime implements RuntimeExtensionInterface
     {
         $query = new Filter();
         $query->withCriterion(new Criterion\ContentTypeIdentifier($contentTypeIdentifier));
-        $query->withLimit(0);
+        $query->withLimit(1);
 
         return $this->contentService->find($query)->getTotalCount() ?? 0;
     }

--- a/bundle/Templating/Twig/BetterIbexaAdminUIRuntime.php
+++ b/bundle/Templating/Twig/BetterIbexaAdminUIRuntime.php
@@ -20,10 +20,10 @@ final class BetterIbexaAdminUIRuntime implements RuntimeExtensionInterface
 
     public function countContentByContentType(string $contentTypeIdentifier): int
     {
-        $query = new Filter();
-        $query->withCriterion(new Criterion\ContentTypeIdentifier($contentTypeIdentifier));
-        $query->withLimit(1);
+        $filter = new Filter();
+        $filter->withCriterion(new Criterion\ContentTypeIdentifier($contentTypeIdentifier));
+        $filter->withLimit(1);
 
-        return $this->contentService->find($query)->getTotalCount() ?? 0;
+        return $this->contentService->find($filter)->getTotalCount() ?? 0;
     }
 }


### PR DESCRIPTION
Limit value 0 means no limit. If the content type has 5000 instances of content, it would retrieve all 5000 at the same time, leading to enormous load times and memory consumption
Since we only need a totalCount value from this filter result, limit should be set to 1.

Also renamed 'query' to 'filter' to match the variable name with used class. 