### PR TITLE
Fix title translation

### DIFF
--- a/bundle/Resources/views/themes/ngadmin/ui/dashboard/dashboard.html.twig
+++ b/bundle/Resources/views/themes/ngadmin/ui/dashboard/dashboard.html.twig
@@ -1,3 +1,5 @@
 {% extends '@admin/ui/dashboard/dashboard.html.twig' %}
 
+{% trans_default_domain 'dashboard' %}
+
 {% block title %}{{ 'my.dashboard'|trans|desc('My dashboard') }}{% endblock %}


### PR DESCRIPTION
Otherwise this does not work on production, in dev it shows the default 'My dashboard' text from `desc` filter.