### PR TITLE
NGSTACK-819: reconfigure services to use FilterService search adapter from Netgen Site API

### DIFF
--- a/bundle/DependencyInjection/Compiler/SearchOverridePass.php
+++ b/bundle/DependencyInjection/Compiler/SearchOverridePass.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\BetterIbexaAdminUIBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Ibexa\AdminUi\Tab\Dashboard\MyContentTab;
+use Ibexa\AdminUi\Tab\Dashboard\EveryoneContentTab;
+use Ibexa\AdminUi\Tab\Dashboard\MyMediaTab;
+use Ibexa\AdminUi\Tab\Dashboard\EveryoneMediaTab;
+use Ibexa\AdminUi\Tab\LocationView\LocationsTab;
+use Ibexa\AdminUi\UI\Service\PathService;
+use Ibexa\GraphQL\DataLoader\SearchContentLoader;
+use Ibexa\GraphQL\DataLoader\SearchLocationLoader;
+use Ibexa\AdminUi\UI\Module\ContentTree\NodeFactory;
+use Ibexa\Bundle\AdminUi\Controller\SectionController;
+use Ibexa\AdminUi\UniversalDiscovery\UniversalDiscoveryProvider;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class SearchOverridePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('netgen.ibexa_site_api.filter_service.search_adapter')) {
+            return;
+        }
+
+        $serviceIds = [
+            PathService::class,
+            MyContentTab::class,
+            EveryoneContentTab::class,
+            MyMediaTab::class,
+            EveryoneMediaTab::class,
+            LocationsTab::class,
+            SearchContentLoader::class,
+            SearchLocationLoader::class,
+            NodeFactory::class,
+            SectionController::class,
+            UniversalDiscoveryProvider::class,
+        ];
+
+        foreach ($serviceIds as $serviceId) {
+            $container->findDefinition($serviceId)->setArgument(
+                '$searchService',
+                new Reference('netgen.ibexa_site_api.filter_service.search_adapter'),
+            );
+        }
+    }
+}

--- a/bundle/NetgenBetterIbexaAdminUIBundle.php
+++ b/bundle/NetgenBetterIbexaAdminUIBundle.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Netgen\Bundle\BetterIbexaAdminUIBundle;
 
+use Netgen\Bundle\BetterIbexaAdminUIBundle\DependencyInjection\Compiler\SearchOverridePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class NetgenBetterIbexaAdminUIBundle extends Bundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new SearchOverridePass());
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
     "require": {
         "ibexa/admin-ui": "^4.4"
     },
+    "require-dev": {
+        "netgen/ibexa-site-api": "^5.4",
+        "ibexa/graphql": "^4.5"
+    },
     "autoload": {
         "psr-4": {
             "Netgen\\Bundle\\BetterIbexaAdminUIBundle\\": "bundle"


### PR DESCRIPTION
This will replace `SearchService` in Admin UI with `FilterService` adapter form Netgen Site API, effectively replacing Solr/Elasticsearch Search Engine with Legacy Search Engine.